### PR TITLE
Add minimum version for requests to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='python-nest',
       author_email='jason@koelker.net',
       url='https://github.com/jkoelker/python-nest/',
       packages=['nest'],
-      install_requires=['requests'],
+      install_requires=['requests>=1.0.0'],
       entry_points={
           'console_scripts': ['nest=nest.command_line:main'],
       }


### PR DESCRIPTION
python-nest requires requests.adapters, which was first included in requests version 1.0.0. Require at least this version when installing.
